### PR TITLE
[WIP] jRuby tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.1.0
   - 2.2.0
   - 2.3.0
   - 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+sudo: false
+
+rvm:
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
+  - 2.3.3
+  - 2.4.0
+  - 2.4.4
+  - 2.5.0
+  - 2.5.3
+  - jruby-9.2.0.0
+
+before_install: gem install bundler
+script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,14 @@ source 'https://rubygems.org'
 
 gem 'rspec'
 gem 'rspec-collection_matchers'
-gem 'sqlite3'
-gem 'byebug'
+
+platform :ruby do
+  gem 'sqlite3'
+  gem 'pry'
+  gem 'pry-byebug'
+end
+
+platform :jruby do
+  gem 'ruby-debug'
+  gem 'jdbc-sqlite3'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,53 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (6.0.2)
-    diff-lcs (1.2.5)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-collection_matchers (1.1.2)
+    byebug (10.0.2)
+    coderay (1.1.2)
+    columnize (0.9.0)
+    diff-lcs (1.3)
+    jdbc-sqlite3 (3.20.1)
+    linecache (1.3.1-java)
+    method_source (0.9.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-collection_matchers (1.1.3)
       rspec-expectations (>= 2.99.0.beta1)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
-    sqlite3 (1.3.10)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    ruby-debug (0.10.6)
+      columnize (>= 0.1)
+      linecache (~> 1.3.1)
+      ruby-debug-base (~> 0.10.6.0)
+    ruby-debug-base (0.10.6-java)
+    sqlite3 (1.3.13)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
-  byebug
+  jdbc-sqlite3
+  pry
+  pry-byebug
   rspec
   rspec-collection_matchers
+  ruby-debug
   sqlite3
+
+BUNDLED WITH
+   1.17.1


### PR DESCRIPTION
**Not to be merged, just a POC!**

This PR contains some changes to test what would be involved to get this working with jRuby as well as normal MRI.

Turns out, it is not as straightforward to use SQLite3 in jRuby as it is in MRI. 
With the following changes, at least a database connection can now be established:

* Instead of the `sqlite3` gem, the following gems have to be present:
  * `dbi`
  * `dbd-jdbc`
  * `jdbc-sqlite3`
* `java` has to be required as the driver is simply a jar file
* `Jdbc::SQLite3.load_driver` has to be called to actually load the driver
* The database has to be opened using `DBI` as an abstraction layer (at least that's the only way I managed to do it by now)

I did not proceed here as the interfaces of `DBI::DatabaseHandle` and the subsequent classes are completely different from the normal SQLite3 gem and would therefore require a lot of conditional code.

If jRuby support is needed, I would suggest creating two different connector files, one for MRI and one for jRuby. Otherwise, everything will become even more cluttered than it is now (even though that's a bit by design).
 